### PR TITLE
Acme.sh reset fix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,11 +3,11 @@
 1. Clone this repo onto the VM that you want to run this code on.
 2. Switch to root (needed for some of these commands)
 3. Setup your environment variables (run `./envSetup.sh -h` for more information)
-4. Setup the environment with `./envSetup.sh`
-   1. Run `git submodule init` to initialize the acme.sh submodule. 
-   2. You can use the `-i` flag to have it install the prereqs of docker and acme.sh, and disable systemd-resolved.
-   3. You can use the `-p` flag to install and configure a squid proxy on port 3128
-5. Clean up the environment by running `./envSetup.sh -r` and then a `git reset --hard`.
+4. Run `git submodules init` and `chmod +x envSetup.sh exportCert.sh`
+5. Setup the environment with `./envSetup.sh` 
+   1. You can use the `-i` flag to have it install the prereqs of docker and acme.sh, and disable systemd-resolved.
+   2. You can use the `-p` flag to install and configure a squid proxy on port 3128
+6. Clean up the environment by running `./envSetup.sh -r`. You will need to re-set the vars file after this. 
 
 # Environment explanation
 

--- a/envSetup.sh
+++ b/envSetup.sh
@@ -317,6 +317,13 @@ InstallTunnelAppliance() {
     ./mstunnel-setup
 }
 
+SetupTunnelPrereqs() {
+    # make the correct directories
+    mkdir /etc/mstunnel
+    mkdir /etc/mstunnel/certs
+    mkdir /etc/mstunnel/private
+}
+
 ###########################################################################################
 #                                                                                         #
 #                                  Update Tunnel Certs                                    #
@@ -447,6 +454,7 @@ done
 # setup server name
 VerifyEnvironmentVars
 ReplaceNames
+SetupTunnelPrereqs
 
 if [[ !$SKIP_CERT_GENERATION ]]; then
     ConfigureCerts

--- a/envSetup.sh
+++ b/envSetup.sh
@@ -306,6 +306,9 @@ BuildAndRunWebService() {
 #                                                                                         #
 ###########################################################################################
 InstallTunnelAppliance() {
+    # Touch EULA
+    touch /etc/mstunnel/EulaAccepted
+
     # Download the installation script 
     wget --output-document=mstunnel-setup https://aka.ms/microsofttunneldownload
     chmod +x ./mstunnel-setup

--- a/envSetup.sh
+++ b/envSetup.sh
@@ -13,7 +13,7 @@ InstallPrereqs() {
     systemctl stop systemd-resolved
 
 	cd acme.sh
-
+    
 	./acme.sh --install -m $EMAIL
 	
 	cd ..
@@ -70,6 +70,8 @@ Uninstall() {
     mst-cli uninstall
 
     git reset --hard
+    git pull --recurse-submodules # Needed to reset acme.sh
+    chmod +x envSetup.sh exportCert.sh 
 }
 
 VerifyEnvironmentVars() {
@@ -310,14 +312,6 @@ InstallTunnelAppliance() {
 
     # Install
     ./mstunnel-setup
-}
-
-SetupTunnelPrereqs() {
-    # make the correct directories
-    mkdir /etc/mstunnel
-    mkdir /etc/mstunnel/certs
-    mkdir /etc/mstunnel/private
-    touch /etc/mstunnel/EulaAccepted
 }
 
 ###########################################################################################

--- a/envSetup.sh
+++ b/envSetup.sh
@@ -413,6 +413,7 @@ do
     case "${options}" in
         h)
             Help
+	    exit
             ;;
         r)
             Uninstall

--- a/envSetup.sh
+++ b/envSetup.sh
@@ -435,6 +435,7 @@ do
             ;;
         ?)
             Help
+	    exit
             ;;
     esac
 done


### PR DESCRIPTION
Fixing acme.sh folder going blank on reset. 
Script runs now even if you goof the first attempt. 
Small updates to ReadMe so user remembers to chmod the export cert script. 