### PR TITLE
First pass at IPv6 support

### DIFF
--- a/CreateServer.ps1
+++ b/CreateServer.ps1
@@ -160,6 +160,11 @@ param(
     [Parameter(Mandatory = $false, ParameterSetName = "ProfilesOnly")]
     [string[]]$ExcludeRoutes = @(),
 
+    [Parameter(Mandatory = $false, ParameterSetName = "Create")]
+    [Parameter(Mandatory = $false, ParameterSetName = "ADFS")]
+    [Parameter(Mandatory = $false, ParameterSetName = "SprintSignoff")]
+    [switch]$WithIPv6,
+
     [Parameter(Mandatory = $false, ParameterSetName = "ADFS")]
     [switch]$WithADFS,
 
@@ -270,7 +275,7 @@ Function Initialize {
         $script:Context.Image = "OpenLogic:CentOS:7_9:latest"
     }
     else {
-        $script:Context.Image = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest"
+        $script:Context.Image = $Image
     }
     
     if ($NoPki) {
@@ -319,6 +324,7 @@ Function Initialize-Variables {
     $script:Context.NoPACUrl = $NoPACUrl
     $script:Context.UseInspection = $UseInspection
     $script:Context.UseAllowList = $UseAllowList
+    $script:Context.WithIPv6 = $WithIPv6
 
     $script:Context.Account = (az account show | ConvertFrom-Json)
     $script:Context.Subscription = $Context.Account.id
@@ -552,6 +558,10 @@ Function New-Summary {
             Write-Success $Allowlist
             Write-Success ""
         }
+    }
+    if ($Context.WithIPv6) {
+        Write-Success "Tunnel Server IPv6 address: $($Context.TunnelIPv6Address)"
+        Write-Success "Service Server IPv6 address: $($Context.TunnelServiceIPv6Address)"
     }
 
     Write-Success "DNS Server: $($Context.ProxyIP)"

--- a/Readme.md
+++ b/Readme.md
@@ -66,13 +66,14 @@ Switches:
 - `-StayLoggedIn` - Stay logged in to the accounts after the script finishes.
 - `-UseInspection` - Configures proxy to use TLS inspection (Break and Inspect).
 - `-UseAllowList` - Configures proxy to use an allow list.
-- `-SprintSignoff` - Setups the services on a VM, and sets up a linux VM ready for tunnel installation, but doesn't create profiles or install Tunnel.
+- `-SprintSignoff` - Sets up the services on a VM, and sets up a linux VM ready for tunnel installation, but doesn't create profiles or install Tunnel.
 - `-NoPACUrl` - Doesn't configure a PAC file when used with ProfilesOnly.
 - `-WithADFS` - Configure ADFS in the environment. This is a WIP and is not fully functional yet.
 - `-RHEL8` - Uses the RHEL 8 lvm image for the Tunnel VM.
 - `-RHEL7` - Uses the RHEL 7 lvm image for the Tunnel VM.
 - `-Centos7` - Uses the Centos 7.9 image from OpenLogic for the Tunnel VM.
 - `-BootDiagnostics` - Turn on boot diagnostics on the Tunnel VM.
+- `-WithIPv6` - Create IPv6 address for the VMs, in addition to the IPv4 addresses.
 
 ## Environment explanation
 The test environment will consist of the following components:

--- a/scripts/TunnelAzure.ps1
+++ b/scripts/TunnelAzure.ps1
@@ -155,7 +155,7 @@ Function New-AdvancedNetworkRules {
 
 Function New-ServiceVM {    
     Write-Header "Creating VM '$($Context.VmName)-server'..."
-    az vm create --location $Context.Location --resource-group $Context.ResourceGroup --name "$($Context.VmName)-server" --image $Context.Image --size $Context.Size --ssh-key-values "$($Context.SSHKeyPath).pub" --public-ip-address-dns-name "$($Context.VmName)-server" --admin-username $Context.Username --vnet-name $Context.VnetName --subnet $Context.SubnetName --only-show-errors | Out-Null
+    az vm create --location $Context.Location --resource-group $Context.ResourceGroup --name "$($Context.VmName)-server" --image $([Constants]::ServerVMImage) --size $Context.Size --ssh-key-values "$($Context.SSHKeyPath).pub" --public-ip-address-dns-name "$($Context.VmName)-server" --admin-username $Context.Username --vnet-name $Context.VnetName --subnet $Context.SubnetName --only-show-errors | Out-Null
 }
 
 Function Update-RebootVM {

--- a/scripts/TunnelHelpers.ps1
+++ b/scripts/TunnelHelpers.ps1
@@ -68,6 +68,7 @@ Class TunnelContext {
 Class Constants {
     static [string] $CertFileName = "cacert.pem.tmp"
     static [string[]] $DefaultBypassUrls = @("www.google.com", "excluded", "excluded.$($Context.TunnelFQDN)")
+    static [string] $ServerVMImage = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest"
 }
 
 Function Set-Endpoints() {

--- a/scripts/getPublicCert.sh
+++ b/scripts/getPublicCert.sh
@@ -66,6 +66,15 @@ CopyAndPrintCertificate() {
     cat ./letsencrypt.pem
 }
 
+OpenPort443()
+{
+    # Red Hat distros typically have a software firewall with port 443 closed. This command opens it.
+    # Ubuntu systems don't usually have firewall-cmd installed, so this command does nothing on Ubuntu.
+    if type firewall-cmd &> /dev/null; then
+        firewall-cmd --zone=public --add-port=443/tcp > /dev/null 2>&1
+    fi
+}
+
 while getopts ":e:d:" opt; do
     case $opt in
         d)
@@ -100,5 +109,6 @@ if [ -z "$DOMAIN_NAME" ]; then
 fi
 
 SetupPrereqs
+OpenPort443
 SetupAcmesh
 CopyAndPrintCertificate


### PR DESCRIPTION
Added the -WithIPv6 flag and did initial pass of support for having the VM and the server VM both have IPV6 addresses. This isn't fully working yet, but I need to commit and move on to other work.

Also, fixed the -Image flag. It always used the default Ubuntu image, rather the the image provided.

Also fixed a bug where the specified Image was used for both VMs. The Image should be used for the gateway VM, but not for the server VM.