### PR TITLE
Add IPv6 addresses for both VMs, when the -WithIPv6 switch is provided.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,25 +7,9 @@
         {
             "type": "PowerShell",
             "request": "launch",
-            "name": "Create TunnelTestEnv",
-            "script": "${file}",
-            "args": ["-SubscriptionId <mySubscriptionId> -VmName <myVMName> -GroupName <myGroupName>"],
-            "cwd": "${workspaceRoot}"
-        },
-        {
-            "type": "PowerShell",
-            "request": "launch",
-            "name": "Delete TunnelTestEnv",
-            "script": "${file}",
-            "args": ["-Delete -SubscriptionId <mySubscriptionId> -VmName <myVMName>"],
-            "cwd": "${workspaceRoot}"
-        },
-        {
-            "type": "PowerShell",
-            "request": "launch",
             "name": "Create Signoff TunnelTestEnv",
             "script": ".\\CreateServer.ps1",
-            "args": ["-SprintSignoff -SubscriptionId <mySubscriptionId> -Image RedHat:RHEL:9-LVM:latest-BootDiagnostics -VmName <myVMName>"],
+            "args": ["-SprintSignoff -SubscriptionId 34f2279c-2de9-44d7-98c6-e0533cd70bd8 -Image RedHat:RHEL:9-lvm:9.2.2023062319 -BootDiagnostics -StayLoggedIn -WithIPv6 -VmName tunnelsignofftest2"],
             "cwd": "${workspaceRoot}"
         },
         {
@@ -33,7 +17,7 @@
             "request": "launch",
             "name": "Delete Signoff TunnelTestEnv",
             "script": ".\\CreateServer.ps1",
-            "args": ["-DeleteSprintSignoff -SubscriptionId <mySubscriptionId> -SprintSignoff -VmName <myVMName>"],
+            "args": ["-DeleteSprintSignoff -SubscriptionId 34f2279c-2de9-44d7-98c6-e0533cd70bd8 -SprintSignoff -StayLoggedIn -VmName tunnelsignofftest2"],
             "cwd": "${workspaceRoot}"
         },
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,9 +7,25 @@
         {
             "type": "PowerShell",
             "request": "launch",
+            "name": "Create TunnelTestEnv",
+            "script": "${file}",
+            "args": ["-SubscriptionId <mySubscriptionId> -VmName <myVMName> -GroupName <myGroupName>"],
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "Delete TunnelTestEnv",
+            "script": "${file}",
+            "args": ["-Delete -SubscriptionId <mySubscriptionId> -VmName <myVMName>"],
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
             "name": "Create Signoff TunnelTestEnv",
             "script": ".\\CreateServer.ps1",
-            "args": ["-SprintSignoff -SubscriptionId 34f2279c-2de9-44d7-98c6-e0533cd70bd8 -Image RedHat:RHEL:9-lvm:9.2.2023062319 -BootDiagnostics -StayLoggedIn -WithIPv6 -VmName tunnelsignofftest2"],
+            "args": ["-SprintSignoff -SubscriptionId <mySubscriptionId> -Image RedHat:RHEL:9-LVM:latest-BootDiagnostics -VmName <myVMName>"],
             "cwd": "${workspaceRoot}"
         },
         {
@@ -17,7 +33,7 @@
             "request": "launch",
             "name": "Delete Signoff TunnelTestEnv",
             "script": ".\\CreateServer.ps1",
-            "args": ["-DeleteSprintSignoff -SubscriptionId 34f2279c-2de9-44d7-98c6-e0533cd70bd8 -SprintSignoff -StayLoggedIn -VmName tunnelsignofftest2"],
+            "args": ["-DeleteSprintSignoff -SubscriptionId <mySubscriptionId> -SprintSignoff -VmName <myVMName>"],
             "cwd": "${workspaceRoot}"
         },
     ]

--- a/CreateServer.ps1
+++ b/CreateServer.ps1
@@ -404,13 +404,6 @@ Function New-TunnelEnvironment {
         
         $script:Context.ProxyIP = Get-ProxyPrivateIP -VmName $ServiceVMName
 
-        if (-Not $Simple) {
-            New-AdvancedNetworkRules
-        }
-        else {
-            New-NetworkRules
-        }
-
         # Create Certificates
         New-BasicPki
         # Setup DNS
@@ -472,13 +465,6 @@ Function New-SprintSignoffEnvironment {
         New-ServiceVM
 
         $script:Context.ProxyIP = Get-ProxyPrivateIP -VmName $ServiceVMName
-
-        if (-Not $Simple) {
-            New-AdvancedNetworkRules
-        }
-        else {
-            New-NetworkRules
-        }
 
         # Create Certificates
         New-BasicPki
@@ -560,8 +546,9 @@ Function New-Summary {
         }
     }
     if ($Context.WithIPv6) {
-        Write-Success "Tunnel Server IPv6 address: $($script:Context.TunnelGatewayIPv6Address).ipAddress"
-        Write-Success "Service Server IPv6 address: $($script:Context.TunnelGatewayIPv6Address).ipAddress"
+        Write-Success "Tunnel Server IPv6 address: $($script:Context.TunnelGatewayIPv6Address.ipAddress)"
+        Write-Success "Service Server IPv6 address: $($script:Context.TunnelServiceIPv6Address.ipAddress)"
+        Write-Success ""
     }
 
     Write-Success "DNS Server: $($Context.ProxyIP)"

--- a/CreateServer.ps1
+++ b/CreateServer.ps1
@@ -560,8 +560,8 @@ Function New-Summary {
         }
     }
     if ($Context.WithIPv6) {
-        Write-Success "Tunnel Server IPv6 address: $($Context.TunnelIPv6Address)"
-        Write-Success "Service Server IPv6 address: $($Context.TunnelServiceIPv6Address)"
+        Write-Success "Tunnel Server IPv6 address: $($script:Context.TunnelGatewayIPv6Address).ipAddress"
+        Write-Success "Service Server IPv6 address: $($script:Context.TunnelGatewayIPv6Address).ipAddress"
     }
 
     Write-Success "DNS Server: $($Context.ProxyIP)"

--- a/scripts/TunnelAzure.ps1
+++ b/scripts/TunnelAzure.ps1
@@ -73,41 +73,68 @@ Function New-Network {
     Write-Header "Creating network $($Context.VnetName)..."
 
     az network nsg create --name $NsgName --resource-group $Context.ResourceGroup --only-show-errors | Out-Null
-    $LocalIP = Invoke-WebRequest https://api.ipify.org
+    if (!$Context.WithIPv6) {
+        # Create IPv4 network.
+        $LocalIP = Invoke-WebRequest https://api.ipify.org
 
-    $LocalIP = $LocalIP.Content
-    $LocalIP = $LocalIP.Split(".") | Select -Index 0,1
-    $LocalIP = $LocalIP | Join-String -Separator "."
-    $LocalIP = "$LocalIP.0.0/16"
+        $LocalIP = $LocalIP.Content
+        $LocalIP = $LocalIP.Split(".") | Select -Index 0,1
+        $LocalIP = $LocalIP | Join-String -Separator "."
+        $LocalIP = "$LocalIP.0.0/16"
 
-    $addressPrefixes = [System.Collections.ArrayList]@()
-    $addressPrefixes.Add("10.0.0.0/16") | Out-Null
-    if ($Context.WithIPv6) {
+        az network nsg rule create --resource-group $Context.ResourceGroup --nsg-name $NsgName --name "AllowSSHIN" --priority 1000  --source-address-prefixes "$LocalIP" --source-port-ranges '*' --destination-port-ranges 22 --access Allow --protocol Tcp --direction Inbound --only-show-errors | Out-Null
+    
+        az network nsg rule create --resource-group $Context.ResourceGroup --nsg-name $NsgName --name "AllowHTTPSIn" --priority 100 --source-address-prefixes 'Internet' --source-port-ranges '*' --destination-address-prefixes '*' --destination-port-ranges 443 --access Allow --protocol '*' --description "Allow HTTPS" --only-show-errors | Out-Null
+    
+        az network vnet create --name $Context.VnetName --resource-group $Context.ResourceGroup --only-show-errors | Out-Null
+        az network vnet subnet create --network-security-group $NsgName --vnet-name $Context.VnetName --name "$($Context.SubnetName)" --address-prefixes "10.0.0.0/24" --resource-group $Context.ResourceGroup --only-show-errors | Out-Null
+
+        # When Azure creates a NIC, it will be named <VMName>VMNic.
+        $script:Context.NicName = "$($Context.VmName)VMNic"
+    }
+    else {
+        # Create IPv6 network.
+
+        $TunnelGatewayIPv4Address = $null
+
+        $addressPrefixes = [System.Collections.ArrayList]@()
+        $subnetPrefixes = [System.Collections.ArrayList]@()
+
         # Reserve some IPv6 addresses with a prefix, then allocate two of them, one for the tunnel VM and one for the service VM.
-        $prefixName = "$($Context.VmName)prefix"
-        $prefixLength = 126 # We'll reserve 4 IP addresses in the prefix.
-        Write-Header "Creating IPv6 prefix $prefixName..."
-        $prefix = az network public-ip prefix create --length $prefixLength --name $prefixName --resource-group $Context.ResourceGroup --version IPv6 | ConvertFrom-Json
-        $ipv6Prefix = Get-IPv6Prefix $prefix.ipPrefix 64  # When we create the subnet, Azure requires a /64 length.
-        $addressPrefixes.Add($ipv6Prefix) | Out-Null
+        # $prefixName = "$($Context.VmName)prefix"
+        # $prefixLength = 126 # We'll reserve 4 IP addresses in the prefix.
+        # Write-Header "Creating IPv6 prefix $prefixName..."
+        # $prefix = az network public-ip prefix create --length $prefixLength --name $prefixName --resource-group $Context.ResourceGroup --version IPv6 | ConvertFrom-Json
+        # $ipv6Prefix = Get-IPv6Prefix $prefix.ipPrefix 64  # When we create the subnet, Azure requires a /64 length.
+        # $addressPrefixes.Add($ipv6Prefix) | Out-Null
         
         Write-Header "Creating IPv6 adresses..."
-        $ipAddressName = "$($Context.VmName)ipv6"
-        $publicIP = az network public-ip create --name $ipAddressName --resource-group $Context.ResourceGroup --allocation-method Static --public-ip-prefix $prefixName --version IPv6 | ConvertFrom-Json
-        $script:Context.TunnelIPv6Name = $publicIP.publicIp.name
-        $script:Context.TunnelIPv6Address = $publicIP.publicIp.ipAddress
-        $ipAddressName = "$($Context.VmName)serviceipv6"
-        $publicIP = az network public-ip create --name $ipAddressName --resource-group $Context.ResourceGroup --allocation-method Static --public-ip-prefix $prefixName --version IPv6 | ConvertFrom-Json
-        $script:Context.TunnelServiceIPv6Name = $publicIP.publicIp.name
-        $script:Context.TunnelServiceIPv6Address = $publicIP.publicIp.ipAddress
-    }
-    
-    az network nsg rule create --resource-group $Context.ResourceGroup --nsg-name $NsgName --name "AllowSSHIN" --priority 1000  --source-address-prefixes "$LocalIP" --source-port-ranges '*' --destination-port-ranges 22 --access Allow --protocol Tcp --direction Inbound --only-show-errors | Out-Null
-    
-    az network nsg rule create --resource-group $Context.ResourceGroup --nsg-name $NsgName --name "AllowHTTPSIn" --priority 100 --source-address-prefixes 'Internet' --source-port-ranges '*' --destination-address-prefixes '*' --destination-port-ranges 443 --access Allow --protocol '*' --description "Allow HTTPS" --only-show-errors | Out-Null
+        $ipAddressName = "$($Context.VmName)ipv4"
+        $dnsName = "$($Context.VmName)ipv4"
+        $publicIp = az network public-ip create --name $ipAddressName --resource-group $Context.ResourceGroup --version IPv4 --allocation-method Static --sku Standard --dns-name $dnsName | ConvertFrom-Json
+        $addressPrefixes.Add((Get-IPv4Prefix $publicIp.publicIp.ipAddress 16))
+        $subnetPrefixes.Add((Get-IPv4Prefix $publicIp.publicIp.ipAddress 24))
+        $TunnelGatewayIPv4Address = $($publicIp.publicIp)
 
-    az network vnet create --name $Context.VnetName --resource-group $Context.ResourceGroup --address-prefixes $addressPrefixes --only-show-errors | Out-Null
-    az network vnet subnet create --network-security-group $NsgName --vnet-name $Context.VnetName --name "$($Context.SubnetName)" --address-prefixes $addressPrefixes --resource-group $Context.ResourceGroup --only-show-errors | Out-Null
+        $ipAddressName = "$($Context.VmName)ipv6"
+        $dnsName = "$($Context.VmName)ipv6"
+        $publicIp = az network public-ip create --name $ipAddressName --resource-group $Context.ResourceGroup --version IPv6 --allocation-method Static --sku Standard --dns-name $dnsName | ConvertFrom-Json
+        $addressPrefixes.Add((Get-IPv6Prefix $publicIp.publicIp.ipAddress 63))
+        $subnetPrefixes.Add((Get-IPv6Prefix $publicIp.publicIp.ipAddress 64))
+        $script:Context.TunnelGatewayIPv6Address = $($publicIp.publicIp)
+
+        #$ipAddressName = "$($Context.VmName)serviceipv6"
+        #$publicIp = az network public-ip create --name $ipAddressName --resource-group $Context.ResourceGroup --allocation-method Static --public-ip-prefix $prefixName --version IPv6 --allocation-method Static | ConvertFrom-Json
+        #$script:Context.TunnelServiceIPv6Address = ($publicIp.publicIp)
+    
+        az network vnet create --name $Context.VnetName --resource-group $Context.ResourceGroup --address-prefixes $addressPrefixes --subnet-name myBackendSubnet --subnet-prefixes $subnetPrefixes --only-show-errors | Out-Null
+
+        $nicName = "$($Context.VmName)nic"
+        Write-Header "Creating Network Interface Card '$nicName'..."
+        az network nic create --resource-group $Context.ResourceGroup --name $nicName --vnet-name $Context.VnetName --subnet $Context.SubnetName --network-security-group $NsgName --private-ip-address 10.0.0.4 | Out-Null
+        az network nic ip-config create --resource-group $Context.ResourceGroup --nic-name $nicName --name ipconfigIPv6 --private-ip-address-version IPv6 --public-ip-address $($script:Context.TunnelGatewayIPv6Address).id | Out-Null
+        $script:Context.NicName = $nicName
+    }
 }
 
 Function Remove-SSHRule {
@@ -119,7 +146,14 @@ Function Remove-SSHRule {
 
 Function New-TunnelVM {    
     Write-Header "Creating VM '$($Context.VmName)'..."
-    az vm create --location $Context.Location --resource-group $Context.ResourceGroup --name $Context.VmName --image $Context.Image --size $Context.Size --ssh-key-values "$($Context.SSHKeyPath).pub" --public-ip-address-dns-name $Context.VmName --admin-username $Context.Username --vnet-name $Context.VnetName --subnet $Context.SubnetName --only-show-errors | Out-Null
+    if ($Context.WithIPv6) {
+        # Create a VM with our NIC.
+        az vm create --location $Context.Location --resource-group $Context.ResourceGroup --name $Context.VmName --image $Context.Image --size $Context.Size --ssh-key-values "$($Context.SSHKeyPath).pub" --public-ip-address-dns-name $Context.VmName --admin-username $Context.Username --only-show-errors --nics $Context.NicName | Out-Null
+    } 
+    else {
+        # Create a VM, and let Azure create a NIC.
+        az vm create --location $Context.Location --resource-group $Context.ResourceGroup --name $Context.VmName --image $Context.Image --size $Context.Size --ssh-key-values "$($Context.SSHKeyPath).pub" --public-ip-address-dns-name $Context.VmName --admin-username $Context.Username --vnet-name $Context.VnetName --subnet $Context.SubnetName --only-show-errors | Out-Null
+    }
 
     if ($Context.BootDiagnostics) {
         Write-Header "Enabling boot diagnostics..."

--- a/scripts/TunnelHelpers.ps1
+++ b/scripts/TunnelHelpers.ps1
@@ -62,7 +62,8 @@ Class TunnelContext {
     [bool] $WithIPv6 = $false
     [Object] $TunnelGatewayIPv6Address
     [Object] $TunnelServiceIPv6Address
-    [string] $NicName
+    [string] $TunnelNicName
+    [string] $ServiceNicName
 }
 
 Class Constants {

--- a/scripts/TunnelHelpers.ps1
+++ b/scripts/TunnelHelpers.ps1
@@ -47,6 +47,7 @@ Class TunnelContext {
     [string] $TunnelFQDN
     [string] $VnetName
     [string] $SubnetName
+    [string] $NSGName
     [string] $ProxyIP
     [object[]] $SupportedEndpoints = @()
     [pscredential[]] $AuthenticatedProxyCredentials = @()

--- a/scripts/TunnelHelpers.ps1
+++ b/scripts/TunnelHelpers.ps1
@@ -181,6 +181,7 @@ Function New-RandomPassword {
 }
 
 # Give me an IPv6 address, like 2a01:111:f100:3000::a83e:1938 and a prefix length, like 64, and I return a valid prefix string, like "2a01:111:f100:3000::/64".
+# This function isn't currently used, but it will be needed when we stop hardcoding the IPv6 address.
 function Get-IPv6Prefix {
     param (
         [string]$IPv6Address,
@@ -241,6 +242,7 @@ function Get-IPv6Prefix {
 }
 
 # Give me an IPv4 address, like 20.253.142.17 and a prefix length, like 16, and I return a valid prefix string, like "20.253.0.0/16".
+# This function isn't currently used, but it may be needed if we ever stop hardcoding the IPv4 private address.
 function Get-IPv4Prefix {
     param (
         [string]$IPAddress,


### PR DESCRIPTION
For both IPv4 and IPv6, we now create a NIC, rather than letting Azure create it for us. For IPv6, we let Azure give us a public IP address, but we hardcode the private IP address. We may need to change this in the future. 

I removed the New-AdvancedNetworkRules and New-NetworkRules functions since the Network Security Rules are created in New-Network, and those functions failed to do anything anyway.

I've added two functions to TunnelHelper.ps1 that create address prefixes for IPv4 and IPv6. These functions aren't currently used, but will be in the future when we stop hardcoding private IP addresses.