### PR TITLE
Support IPv6 quad-A DNS records.

### DIFF
--- a/CreateServer.ps1
+++ b/CreateServer.ps1
@@ -344,7 +344,9 @@ Function Initialize-Variables {
 
     $script:Context.TunnelFQDN = "$VmName.$Location.cloudapp.azure.com"
     $script:Context.ServiceFQDN = "$VmName-server.$Location.cloudapp.azure.com"
-
+    $script:Context.TunnelFQDNIpv6 = "$($VmName)IPv6.$Location.cloudapp.azure.com"
+    $script:Context.ServiceFQDNIpv6 = "$($VmName)IPv6-server.$Location.cloudapp.azure.com"
+    
     if ($PACUrl -eq "") {
         $script:Context.PACUrl = "http://$($Context.TunnelFQDN)/tunnel.pac"
     }
@@ -403,6 +405,7 @@ Function New-TunnelEnvironment {
         New-ServiceVM
         
         $script:Context.ProxyIP = Get-ProxyPrivateIP -VmName $ServiceVMName
+        $script:Context.ProxyIPv6 = Get-ProxyPrivateIPv6 -VmName $ServiceVMName
 
         # Create Certificates
         New-BasicPki
@@ -465,6 +468,7 @@ Function New-SprintSignoffEnvironment {
         New-ServiceVM
 
         $script:Context.ProxyIP = Get-ProxyPrivateIP -VmName $ServiceVMName
+        $script:Context.ProxyIPv6 = Get-ProxyPrivateIPv6 -VmName $ServiceVMName
 
         # Create Certificates
         New-BasicPki

--- a/docs/unbound.md
+++ b/docs/unbound.md
@@ -4,7 +4,7 @@
 
 All DNS entries are stored in the a-records file. You can copy this into the container, or find it in the volume path. e.g. `/var/lib/docker/volumes/unbound/_data/a-records`. After editing this file, you should restart the unbound container to make sure the new entries take effect.
 
-We have added a script to the VM to simplify this process. To add a new DNS entry, simply run `./configureDNS.sh -u -i <ip> -d <domain>`
+We have added a script to the VM to simplify this process. To add a new DNS entry, simply run `./configureDNS.sh -c [-q] -i <ip> -d <domain>`
 
 ## Logs
 

--- a/scripts/SetupServices.ps1
+++ b/scripts/SetupServices.ps1
@@ -50,13 +50,23 @@ Function New-DnsServer {
     scp -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" -r ./unbound.conf.d/unbound.conf "$($Context.Username)@$($Context.ServiceFQDN):~/" > $null
 
     ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "chmod +x ~/configureDNS.sh"
-    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh"
+    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh"   # Configure the Unbound DNS container.
 
-    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -u -i $($Context.ProxyIP) -d $($Context.TunnelFQDN)"
-    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -u -i $($Context.ProxyIP) -d proxy.$($Context.TunnelFQDN)"
-    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -u -i $($Context.ProxyIP) -d trusted.$($Context.TunnelFQDN)"
-    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -u -i $($Context.ProxyIP) -d untrusted.$($Context.TunnelFQDN)"
-    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -u -i $($Context.ProxyIP) -d webapp.$($Context.TunnelFQDN)"
-    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -u -i $($Context.ProxyIP) -d excluded.$($Context.TunnelFQDN)"
-    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -u -i $($Context.ProxyIP) -d cert.$($Context.TunnelFQDN)"
+    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -i $($Context.ProxyIP) -d $($Context.TunnelFQDN)"
+    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -i $($Context.ProxyIP) -d proxy.$($Context.TunnelFQDN)"
+    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -i $($Context.ProxyIP) -d trusted.$($Context.TunnelFQDN)"
+    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -i $($Context.ProxyIP) -d untrusted.$($Context.TunnelFQDN)"
+    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -i $($Context.ProxyIP) -d webapp.$($Context.TunnelFQDN)"
+    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -i $($Context.ProxyIP) -d excluded.$($Context.TunnelFQDN)"
+    ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -i $($Context.ProxyIP) -d cert.$($Context.TunnelFQDN)"
+
+    if ($Context.WithIPv6) {
+        ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -q -i $($Context.ProxyIPv6) -d $($Context.TunnelFQDNIpv6)"
+        ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -q -i $($Context.ProxyIPv6) -d proxy.$($Context.TunnelFQDNIpv6)"
+        ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -q -i $($Context.ProxyIPv6) -d trusted.$($Context.TunnelFQDNIpv6)"
+        ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -q -i $($Context.ProxyIPv6) -d untrusted.$($Context.TunnelFQDNIpv6)"
+        ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -q -i $($Context.ProxyIPv6) -d webapp.$($Context.TunnelFQDNIpv6)"
+        ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -q -i $($Context.ProxyIPv6) -d excluded.$($Context.TunnelFQDNIpv6)"
+        ssh -i $Context.SSHKeyPath -o "StrictHostKeyChecking=no" "$($Context.Username)@$($Context.ServiceFQDN)" "sudo ./configureDNS.sh -c -q -i $($Context.ProxyIPv6) -d cert.$($Context.TunnelFQDNIpv6)"
+    }
 }

--- a/scripts/TunnelHelpers.ps1
+++ b/scripts/TunnelHelpers.ps1
@@ -45,10 +45,13 @@ Class TunnelContext {
     [Object] $Group
     [string] $ServiceFQDN
     [string] $TunnelFQDN
+    [string] $ServiceFQDNIpv6
+    [string] $TunnelFQDNIpv6
     [string] $VnetName
     [string] $SubnetName
     [string] $NSGName
     [string] $ProxyIP
+    [string] $ProxyIPv6
     [object[]] $SupportedEndpoints = @()
     [pscredential[]] $AuthenticatedProxyCredentials = @()
     [Object] $ServerConfiguration

--- a/scripts/TunnelProxy.ps1
+++ b/scripts/TunnelProxy.ps1
@@ -8,6 +8,15 @@ Function Get-ProxyPrivateIP {
     return az vm list-ip-addresses --resource-group $Context.ResourceGroup --name $Context.ProxyVmName --query '[0].virtualMachine.network.privateIpAddresses[0]' | ConvertFrom-Json
 }
 
+Function Get-ProxyPrivateIPv6 {
+    if ($Context.WithIPv6) {
+        return az vm list-ip-addresses --resource-group $Context.ResourceGroup --name $Context.ProxyVmName --query '[0].virtualMachine.network.privateIpAddresses[1]' | ConvertFrom-Json
+    }
+    else {
+        return ""
+    }
+}
+
 Function Initialize-Proxy {
     try {
         $configFile = Join-Path $pwd -ChildPath "proxy" -AdditionalChildPath "squid.conf"

--- a/unbound.conf.d/a-records.conf
+++ b/unbound.conf.d/a-records.conf
@@ -1,5 +1,8 @@
-# A Record
-     # local-data: "##DOMAIN##. A ##IP##"
+# A Records
+# local-data: "##DOMAIN##. A ##IP##"
 
-# PTR Record
-     # local-data-ptr: "##IP## ##DOMAIN##."
+# AAAA Records
+# local-data: "##DOMAIN##. AAAA ##IP##"
+
+# PTR Records
+# local-data-ptr: "##IP## ##DOMAIN##."


### PR DESCRIPTION
With these changes, the a-records.conf file looks like this (Please ignore the big headings. Apparently GitHub thinks comments are headings.):

azureuser@tunnelsignofftest2-server:~$ cat a-records.conf
# A Records
 local-data: "tunnelsignofftest2.westus.cloudapp.azure.com. A 10.0.0.5"
 local-data: "proxy.tunnelsignofftest2.westus.cloudapp.azure.com. A 10.0.0.5"
 local-data: "trusted.tunnelsignofftest2.westus.cloudapp.azure.com. A 10.0.0.5"
 local-data: "untrusted.tunnelsignofftest2.westus.cloudapp.azure.com. A 10.0.0.5"
 local-data: "webapp.tunnelsignofftest2.westus.cloudapp.azure.com. A 10.0.0.5"
 local-data: "excluded.tunnelsignofftest2.westus.cloudapp.azure.com. A 10.0.0.5"
 local-data: "cert.tunnelsignofftest2.westus.cloudapp.azure.com. A 10.0.0.5"
# local-data: "##DOMAIN##. A ##IP##"

# AAAA Records
 local-data: "tunnelsignofftest2IPv6.westus.cloudapp.azure.com. AAAA 2404:f800:8000:122::5"
 local-data: "proxy.tunnelsignofftest2IPv6.westus.cloudapp.azure.com. AAAA 2404:f800:8000:122::5"
 local-data: "trusted.tunnelsignofftest2IPv6.westus.cloudapp.azure.com. AAAA 2404:f800:8000:122::5"
 local-data: "untrusted.tunnelsignofftest2IPv6.westus.cloudapp.azure.com. AAAA 2404:f800:8000:122::5"
 local-data: "webapp.tunnelsignofftest2IPv6.westus.cloudapp.azure.com. AAAA 2404:f800:8000:122::5"
 local-data: "excluded.tunnelsignofftest2IPv6.westus.cloudapp.azure.com. AAAA 2404:f800:8000:122::5"
 local-data: "cert.tunnelsignofftest2IPv6.westus.cloudapp.azure.com. AAAA 2404:f800:8000:122::5"
# local-data: "##DOMAIN##. AAAA ##IP##"

# PTR Records
 local-data-ptr: "10.0.0.5 tunnelsignofftest2.westus.cloudapp.azure.com."
 local-data-ptr: "10.0.0.5 proxy.tunnelsignofftest2.westus.cloudapp.azure.com."
 local-data-ptr: "10.0.0.5 trusted.tunnelsignofftest2.westus.cloudapp.azure.com."
 local-data-ptr: "10.0.0.5 untrusted.tunnelsignofftest2.westus.cloudapp.azure.com."
 local-data-ptr: "10.0.0.5 webapp.tunnelsignofftest2.westus.cloudapp.azure.com."
 local-data-ptr: "10.0.0.5 excluded.tunnelsignofftest2.westus.cloudapp.azure.com."
 local-data-ptr: "10.0.0.5 cert.tunnelsignofftest2.westus.cloudapp.azure.com."
 local-data-ptr: "2404:f800:8000:122::5 tunnelsignofftest2IPv6.westus.cloudapp.azure.com."
 local-data-ptr: "2404:f800:8000:122::5 proxy.tunnelsignofftest2IPv6.westus.cloudapp.azure.com."
 local-data-ptr: "2404:f800:8000:122::5 trusted.tunnelsignofftest2IPv6.westus.cloudapp.azure.com."
 local-data-ptr: "2404:f800:8000:122::5 untrusted.tunnelsignofftest2IPv6.westus.cloudapp.azure.com."
 local-data-ptr: "2404:f800:8000:122::5 webapp.tunnelsignofftest2IPv6.westus.cloudapp.azure.com."
 local-data-ptr: "2404:f800:8000:122::5 excluded.tunnelsignofftest2IPv6.westus.cloudapp.azure.com."
 local-data-ptr: "2404:f800:8000:122::5 cert.tunnelsignofftest2IPv6.westus.cloudapp.azure.com."
# local-data-ptr: "##IP## ##DOMAIN##."